### PR TITLE
Package installation fix

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,8 +45,8 @@ keywords = [
 "Homepage" = "https://github.com/moha-abdi/PySIP"
 "Bug Tracker" = "https://github.com/moha-abdi/PySIP/issues"
 
-[tool.setuptools]
-packages = ["PySIP"]
+[tool.setuptools.packages.find]
+include = ["PySIP", "PySIP.*"]
 
 [tool.setuptools.package-data]
 PySIP = [".github/images/*.png"]


### PR DESCRIPTION
Added python package submodule discovery.

Currently when installing package the submodules are not found which results in an error, even in the example script (if taken out of directory).