### PR TITLE
Feature/incoming calls

### DIFF
--- a/PySIP/codecs/__init__.py
+++ b/PySIP/codecs/__init__.py
@@ -1,13 +1,8 @@
-
 from .g711 import PcmaDecoder, PcmaEncoder, PcmuDecoder, PcmuEncoder
 from .codec_info import CodecInfo
 
 
-CODECS = [
-    CodecInfo.PCMA,
-    CodecInfo.PCMU,
-    CodecInfo.EVENT
-]
+CODECS = [CodecInfo.PCMA, CodecInfo.PCMU, CodecInfo.EVENT]
 
 
 def get_encoder(codec: CodecInfo):
@@ -17,6 +12,7 @@ def get_encoder(codec: CodecInfo):
         return PcmuEncoder()
     else:
         raise ValueError(f"No encoder found for: {codec}")
+
 
 def get_decoder(codec: CodecInfo):
     if codec == CodecInfo.PCMA:

--- a/PySIP/codecs/codec_info.py
+++ b/PySIP/codecs/codec_info.py
@@ -46,9 +46,7 @@ class CodecInfo(Enum):
             return int(self.value)
         except ValueError:
             pass
-        raise Exception(
-            self.description + " is a dynamically assigned payload"
-        )
+        raise Exception(self.description + " is a dynamically assigned payload")
 
     def __str__(self) -> str:
         if isinstance(self.value, int):
@@ -68,6 +66,7 @@ class CodecInfo(Enum):
     L16 = 11, 44100, 1, "L16"
     QCELP = 12, 8000, 1, "QCELP"
     CN = 13, 8000, 1, "CN"
+    OPUS = 107, 48000, 2, "opus"
     # MPA channel varries, should be defined in the RTP packet.
     MPA = 14, 90000, 0, "MPA"
     G728 = 15, 8000, 1, "G728"

--- a/PySIP/sip_client.py
+++ b/PySIP/sip_client.py
@@ -332,7 +332,6 @@ class SipClient:
         # difference is that its handled inside the :obj:`Client`
         # and it's onlt for developer's usage. unlike other handlers
         # it has no filters for now.
-        print(msg.data)
         to = msg.get_header("To")
         if (
             not msg.call_id == self.call_id and self.username not in to

--- a/PySIP/sip_client.py
+++ b/PySIP/sip_client.py
@@ -1,8 +1,10 @@
 import asyncio
 import logging
-from typing import List
+from typing import Callable, Dict, List
 import uuid
 import random
+
+from PySIP.sip_call import SipCall
 
 from .sip_core import SipCore, SipMessage, Counter
 from .filters import SIPCompatibleMethods, SIPStatus, ConnectionType
@@ -10,22 +12,20 @@ from .utils.logger import logger
 from .exceptions import NoPasswordFound
 
 
-__all__ = [
-    'SipClient'
-]
+__all__ = ["SipClient"]
 
 
 class SipClient:
     def __init__(
-        self, 
-        username, 
-        server, 
+        self,
+        username,
+        server,
         connection_type: str,
-        password: str, 
+        password: str,
         *,
-        register_duration = 600,
-        caller_id = "",
-        sip_core = None
+        register_duration=600,
+        caller_id="",
+        sip_core=None,
     ):
         self.username = username
         try:
@@ -38,13 +38,19 @@ class SipClient:
         if password:
             self.password = password
         else:
-            raise NoPasswordFound("No password was provided please provide password to use for Digest auth.")
+            raise NoPasswordFound(
+                "No password was provided please provide password to use for Digest auth."
+            )
 
-        self.CTS = 'TLS' if 'TLS' in connection_type else connection_type
+        self.CTS = "TLS" if "TLS" in connection_type else connection_type
         self.connection_type = ConnectionType(connection_type)
         self.reader, self.writer = None, None
         self.all_tasks: List[asyncio.Task] = []
-        self.sip_core = sip_core if sip_core is not None else SipCore(self.username, self.server, connection_type, password)
+        self.sip_core = (
+            sip_core
+            if sip_core is not None
+            else SipCore(self.username, self.server, connection_type, password)
+        )
         self.call_id = self.sip_core.gen_call_id()
         self.sip_core.on_message_callbacks.append(self.message_handler)
         self.register_counter = Counter(random.randint(1, 2000))
@@ -55,6 +61,7 @@ class SipClient:
         self.caller_id = caller_id if caller_id else username
         self.my_public_ip = None
         self.my_private_ip = None
+        self._callbacks: Dict[str, List[Callable]] = {}
 
     async def run(self):
         register_task = None
@@ -64,18 +71,24 @@ class SipClient:
             self.my_public_ip = await asyncio.to_thread(self.sip_core.get_public_ip)
             self.my_private_ip = await asyncio.to_thread(self.sip_core.get_local_ip)
 
-            if (not self.sip_core.is_running.is_set()
-                    and not self.sip_core._is_connecting.is_set()):
+            if (
+                not self.sip_core.is_running.is_set()
+                and not self.sip_core._is_connecting.is_set()
+            ):
                 # only connect if it is not already connected
                 await self.sip_core.connect()
 
             elif self.sip_core._is_connecting.is_set():
                 await self.sip_core.is_running.wait()
 
-            register_task = asyncio.create_task(self.periodic_register(self.register_duration), name='Periodic Register')
+            register_task = asyncio.create_task(
+                self.periodic_register(self.register_duration), name="Periodic Register"
+            )
             tasks.append(register_task)
             if not self.sip_core.receive_task:
-                receive_task = asyncio.create_task(self.sip_core.receive(), name='Receive Messages Task')
+                receive_task = asyncio.create_task(
+                    self.sip_core.receive(), name="Receive Messages Task"
+                )
                 self.sip_core.receive_task = receive_task
                 tasks.append(self.sip_core.receive_task)
 
@@ -94,7 +107,7 @@ class SipClient:
             return
 
         finally:
-            
+
             if register_task and not register_task.done():
                 register_task.cancel()
                 try:
@@ -115,13 +128,13 @@ class SipClient:
         try:
             await asyncio.wait_for(self.unregistered.wait(), 4)
             logger.log(
-                logging.INFO, 
-                "Sip Account: %s has been de-registered from the server", self.username
+                logging.INFO,
+                "Sip Account: %s has been de-registered from the server",
+                self.username,
             )
         except asyncio.TimeoutError:
             logger.log(
-                logging.WARNING, 
-                "Failed to de-register Sip Account: %s", self.username
+                logging.WARNING, "Failed to de-register Sip Account: %s", self.username
             )
 
         self.sip_core.is_running.clear()
@@ -133,12 +146,13 @@ class SipClient:
             await self.register()
 
             sleep_task = asyncio.create_task(asyncio.sleep(delay - 5))
-            event_cleared_task = asyncio.create_task(self.wait_for_event_clear(self.sip_core.is_running))
+            event_cleared_task = asyncio.create_task(
+                self.wait_for_event_clear(self.sip_core.is_running)
+            )
             self.all_tasks.extend([sleep_task, event_cleared_task])
 
             _, pending = await asyncio.wait(
-                [sleep_task, event_cleared_task],
-                return_when="FIRST_COMPLETED"
+                [sleep_task, event_cleared_task], return_when="FIRST_COMPLETED"
             )
 
             for task in pending:
@@ -147,8 +161,10 @@ class SipClient:
             if not self.sip_core.is_running.is_set():
                 break
 
-        logger.log(logging.DEBUG, "The app will no longer register. Registeration task stopped.")
-
+        logger.log(
+            logging.DEBUG,
+            "The app will no longer register. Registeration task stopped.",
+        )
 
     async def wait_for_event_clear(self, event: asyncio.Event):
         while True:
@@ -161,8 +177,12 @@ class SipClient:
         self.my_public_ip = await asyncio.to_thread(self.sip_core.get_public_ip)
         self.my_private_ip = await asyncio.to_thread(self.sip_core.get_local_ip)
 
-        connection_types = [ConnectionType.UDP, ConnectionType.TCP,
-                            ConnectionType.TLS, ConnectionType.TLSv1]
+        connection_types = [
+            ConnectionType.UDP,
+            ConnectionType.TCP,
+            ConnectionType.TLS,
+            ConnectionType.TLSv1,
+        ]
         found_connections = [ConnectionType.UDP]
         found_connections.clear()
 
@@ -170,13 +190,15 @@ class SipClient:
             self.sip_core.is_running.clear()
             self.sip_core.connection_type = con
             self.connection_type = con
-            self.sip_core.port = 5061 if con in [ConnectionType.TLS, ConnectionType.TLSv1] else 5060
+            self.sip_core.port = (
+                5061 if con in [ConnectionType.TLS, ConnectionType.TLSv1] else 5060
+            )
             try:
                 await self.sip_core.connect()
             except Exception:
                 continue
             await self.register()
-            
+
             reader = self.sip_core.udp_reader or self.sip_core.reader
             if not reader:
                 return found_connections
@@ -187,88 +209,96 @@ class SipClient:
                 continue
         return found_connections
 
-    def build_register_message(self, auth=False, received_message=None, unregister=False):
+    def build_register_message(
+        self, auth=False, received_message=None, unregister=False
+    ):
         # Generate unique identifiers for the message
         branch_id = str(uuid.uuid4()).upper()
         # Initialize transaction
         call_id = self.call_id
-        
+
         # Start building the SIP message based on authentication need
         if auth:
             # Handling authenticated REGISTER request
-            unregister = True if self.register_tags['type'] == "UNREGISTER" else False
+            unregister = True if self.register_tags["type"] == "UNREGISTER" else False
             if not received_message:
                 return
             nonce = received_message.nonce
             realm = received_message.realm
             cseq = next(self.register_counter)
-            self.register_tags['cseq'] = cseq
-            to_tag = self.register_tags['remote_tag'] = received_message.to_tag
-            uri = f'sip:{self.server}:{self.port};transport={self.CTS}'
+            self.register_tags["cseq"] = cseq
+            to_tag = self.register_tags["remote_tag"] = received_message.to_tag
+            uri = f"sip:{self.server}:{self.port};transport={self.CTS}"
             response = self.sip_core.generate_response("REGISTER", nonce, realm, uri)
-            
+
             # Adjust Via and Contact headers for public IP and port if available
             my_public_ip = self.my_public_ip
             ip = received_message.public_ip if not my_public_ip else my_public_ip
             port = received_message.rport
-            from_tag = self.register_tags['local_tag']
+            from_tag = self.register_tags["local_tag"]
             expires = ";expires=0" if unregister else ""
             expires_field = "Expires: 60\r\n" if not unregister else ""
-            
+
             # Construct the REGISTER request with Authorization header
-            msg = (f"REGISTER sip:{self.server};transport={self.CTS} SIP/2.0\r\n"
-                   f"Via: SIP/2.0/{self.CTS} {ip}:{port};rport;branch={received_message.branch};alias\r\n"
-                   f"Max-Forwards: 70\r\n"
-                   f"From: <sip:{self.caller_id}@{self.server}>;tag={from_tag}\r\n"
-                   f"To: <sip:{self.username}@{self.server}>;tag={to_tag}\r\n"
-                   f"Call-ID: {call_id}\r\n"
-                   f"CSeq: {cseq} REGISTER\r\n"
-                   f"Contact: <sip:{self.username}@{ip}:{port};transport={self.CTS};ob>{expires}\r\n" 
-                   f"{expires_field}"
-                   f"Authorization: Digest username=\"{self.username}\", realm=\"{realm}\", nonce=\"{nonce}\", uri=\"{uri}\", response=\"{response}\", algorithm=\"MD5\"\r\n"
-                   f"Content-Length: 0\r\n\r\n")
+            msg = (
+                f"REGISTER sip:{self.server};transport={self.CTS} SIP/2.0\r\n"
+                f"Via: SIP/2.0/{self.CTS} {ip}:{port};rport;branch={received_message.branch};alias\r\n"
+                f"Max-Forwards: 70\r\n"
+                f"From: <sip:{self.caller_id}@{self.server}>;tag={from_tag}\r\n"
+                f"To: <sip:{self.username}@{self.server}>;tag={to_tag}\r\n"
+                f"Call-ID: {call_id}\r\n"
+                f"CSeq: {cseq} REGISTER\r\n"
+                f"Contact: <sip:{self.username}@{ip}:{port};transport={self.CTS};ob>{expires}\r\n"
+                f"{expires_field}"
+                f'Authorization: Digest username="{self.username}", realm="{realm}", nonce="{nonce}", uri="{uri}", response="{response}", algorithm="MD5"\r\n'
+                f"Content-Length: 0\r\n\r\n"
+            )
         else:
             # Handling unauthenticated REGISTER request
             ip = self.my_private_ip
             port = self.port
-            _, my_public_port = self.sip_core.get_extra_info('sockname')
-            if not self.register_tags['local_tag']:
-                self.register_tags['local_tag'] = self.sip_core.generate_tag()
+            _, my_public_port = self.sip_core.get_extra_info("sockname")
+            if not self.register_tags["local_tag"]:
+                self.register_tags["local_tag"] = self.sip_core.generate_tag()
 
             cseq = next(self.register_counter)
             expires = ";expires=0" if unregister else ""
             expires_field = "Expires: 60\r\n" if not unregister else ""
             self.register_tags["type"] = "UNREGISTER" if unregister else "REGISTER"
-            
-            # Construct the REGISTER request without Authorization header
-            msg = (f"REGISTER sip:{self.server};transport={self.CTS} SIP/2.0\r\n"
-                   f"Via: SIP/2.0/{self.CTS} {ip}:{my_public_port};rport;branch={branch_id};alias\r\n"
-                   f"Max-Forwards: 70\r\n"
-                   f"From: <sip:{self.caller_id}@{self.server}>;tag={self.register_tags['local_tag']}\r\n"
-                   f"To: <sip:{self.username}@{self.server}>\r\n"
-                   f"Call-ID: {call_id}\r\n"
-                   f"CSeq: {cseq} REGISTER\r\n"
-                   f"Contact: <sip:{self.username}@{self.my_public_ip}:{my_public_port};transport={self.CTS};ob>{expires}\r\n"
-                   f"{expires_field}"
-                   f"Content-Length: 0\r\n\r\n")
 
-        return msg 
+            # Construct the REGISTER request without Authorization header
+            msg = (
+                f"REGISTER sip:{self.server};transport={self.CTS} SIP/2.0\r\n"
+                f"Via: SIP/2.0/{self.CTS} {ip}:{my_public_port};rport;branch={branch_id};alias\r\n"
+                f"Max-Forwards: 70\r\n"
+                f"From: <sip:{self.caller_id}@{self.server}>;tag={self.register_tags['local_tag']}\r\n"
+                f"To: <sip:{self.username}@{self.server}>\r\n"
+                f"Call-ID: {call_id}\r\n"
+                f"CSeq: {cseq} REGISTER\r\n"
+                f"Contact: <sip:{self.username}@{self.my_public_ip}:{my_public_port};transport={self.CTS};ob>{expires}\r\n"
+                f"{expires_field}"
+                f"Content-Length: 0\r\n\r\n"
+            )
+
+        return msg
 
     def ok_generator(self, data_parsed: SipMessage):
         peer_ip, peer_port = self.sip_core.get_extra_info("peername")
-        _, port = self.sip_core.get_extra_info('sockname')
+        _, port = self.sip_core.get_extra_info("sockname")
         my_public_ip = self.my_public_ip
 
-        msg = "SIP/2.0 200 OK\r\n" 
+        msg = "SIP/2.0 200 OK\r\n"
         msg += f"Via: {data_parsed.get_header('Via')}\r\n"
 
         if data_parsed.method == "OPTIONS":
-            to_tag = self.sip_core.generate_tag() 
+            to_tag = self.sip_core.generate_tag()
             msg += f"From: {data_parsed.get_header('From')}\r\n"
             msg += f"To: <sip:{self.username}@{my_public_ip}>;tag={to_tag}\r\n"
         else:
             msg += f"From: <sip:{self.username}@{self.server}>;tag={data_parsed.from_tag}\r\n"
-            msg += f"To: <sip:{self.username}@{self.server}>;tag={data_parsed.to_tag}\r\n" 
+            msg += (
+                f"To: <sip:{self.username}@{self.server}>;tag={data_parsed.to_tag}\r\n"
+            )
 
         msg += f"Call-ID: {data_parsed.call_id}\r\n"
         msg += f"CSeq: {data_parsed.cseq} {data_parsed.method}\r\n"
@@ -280,10 +310,9 @@ class SipClient:
         return msg
 
     async def ping(self):
-        options_message = "" #TODO Impmelement an options generator when required
+        options_message = ""  # TODO Impmelement an options generator when required
         await self.sip_core.send(options_message)
 
-    
     async def reregister(self, auth, data):
         msg = self.build_register_message(auth, data)
 
@@ -303,10 +332,12 @@ class SipClient:
         # difference is that its handled inside the :obj:`Client`
         # and it's onlt for developer's usage. unlike other handlers
         # it has no filters for now.
+        print(msg.data)
         to = msg.get_header("To")
-        if (not msg.call_id == self.call_id and
-            self.username not in to): # Filter only current call
-            return # These are just for extra check and not necessary
+        if (
+            not msg.call_id == self.call_id and self.username not in to
+        ):  # Filter only current call
+            return  # These are just for extra check and not necessary
 
         await asyncio.sleep(0.001)
         if msg.status == SIPStatus(401) and msg.method == "REGISTER":
@@ -319,12 +350,35 @@ class SipClient:
             logger.log(logging.DEBUG, "Successfully REGISTERED")
 
             # In case the response is of Un-register we set this
-            if self.register_tags['type'] == "UNREGISTER":
-                if msg.cseq == self.register_tags['cseq']:
+            if self.register_tags["type"] == "UNREGISTER":
+                if msg.cseq == self.register_tags["cseq"]:
                     self.unregistered.set()
 
-        elif msg.data.startswith("OPTIONS"): # If we recieve PING then PONG incase of keep-alive required
-            logger.log(logging.DEBUG, "Keep-alive message received from the server. sending OK")
+        elif msg.data.startswith(
+            "OPTIONS"
+        ):  # If we recieve PING then PONG incase of keep-alive required
+            logger.log(
+                logging.DEBUG, "Keep-alive message received from the server. sending OK"
+            )
             options_ok = self.ok_generator(msg)
             await self.sip_core.send(options_ok)
 
+        elif msg.data.startswith("INVITE") and self.username in to:
+            incoming_call = SipCall(
+                self.username, self.password, self.server, "", sip_core=self.sip_core
+            )
+            for cb in self._get_callbacks("incoming_call_cb"):
+                incoming_call._register_callback("incoming_call_cb", cb)
+
+            await incoming_call.handle_incoming_call(msg)
+
+    def _register_callback(self, cb_type, cb):
+        self._callbacks.setdefault(cb_type, []).append(cb)
+
+    def _get_callbacks(self, cb_type):
+        return self._callbacks.get(cb_type, [])
+
+    def _remove_callback(self, cb_type, cb):
+        callbacks = self._callbacks.get(cb_type, [])
+        if cb in callbacks:
+            callbacks.remove(cb)

--- a/PySIP/sip_core.py
+++ b/PySIP/sip_core.py
@@ -46,7 +46,7 @@ connection_ports = {
     ConnectionType.UDP: 5060,
     ConnectionType.TCP: 5060,
     ConnectionType.TLS: 5061,
-    ConnectionType.TLSv1: 5061
+    ConnectionType.TLSv1: 5061,
 }
 
 SAVE_TLS_KEYLOG = False
@@ -389,9 +389,9 @@ class SipDialogue:
         self.call_id = call_id
         self.local_tag = local_tag  # The tag of the party who initiated the dialogue
         self.remote_tag = remote_tag  # The tag of the other party
-        self.transactions: List[
-            SipTransaction
-        ] = []  # List to store transactions related to this dialogue
+        self.transactions: List[SipTransaction] = (
+            []
+        )  # List to store transactions related to this dialogue
         self.cseq = Counter(random.randint(1, 2000))
         self.state = DialogState.PREDIALOG  # Start with the PREDIALOG state
         self.events = {state: asyncio.Event() for state in DialogState}
@@ -460,7 +460,7 @@ class SipDialogue:
         self.events[self.state].set()
 
         if self.state != self.previous_state:
-            logger.log(logging.DEBUG, f"Dialog state changed to -> {self.state}") 
+            logger.log(logging.DEBUG, f"Dialog state changed to -> {self.state}")
 
     @property
     def local_session_info(self):

--- a/PySIP/utils/__init__.py
+++ b/PySIP/utils/__init__.py
@@ -1,10 +1,11 @@
 import asyncio
 import io
+import re
 from edge_tts import Communicate
 from pydub.audio_segment import AudioSegment
 
 
-def mp3_to_wav(f, target_channels = 1, target_framerate = 8000):
+def mp3_to_wav(f, target_channels=1, target_framerate=8000):
     """
     Convert MP3 audio from the temporary chunk to WAV format.
     """
@@ -12,8 +13,9 @@ def mp3_to_wav(f, target_channels = 1, target_framerate = 8000):
     decoded_chunk = AudioSegment.from_mp3(f)
     decoded_chunk = decoded_chunk.set_channels(target_channels)
     decoded_chunk = decoded_chunk.set_frame_rate(target_framerate)
-    decoded_chunk.export(output_chunk, format='wav')
+    decoded_chunk.export(output_chunk, format="wav")
     return output_chunk
+
 
 async def generate_audio(text: str, voice: str) -> io.BytesIO:
     """
@@ -22,9 +24,28 @@ async def generate_audio(text: str, voice: str) -> io.BytesIO:
     com = Communicate(text, voice)
     temp_chunk = io.BytesIO()
     async for chunk in com.stream():
-        if chunk['type'] == 'audio':
-            await asyncio.to_thread(temp_chunk.write, chunk['data'])
+        if chunk["type"] == "audio":
+            await asyncio.to_thread(temp_chunk.write, chunk["data"])
 
     await asyncio.to_thread(temp_chunk.seek, 0)
-    decoded_audio = await asyncio.to_thread(mp3_to_wav, temp_chunk) 
+    decoded_audio = await asyncio.to_thread(mp3_to_wav, temp_chunk)
     return decoded_audio
+
+
+def get_caller_number(invite_message):
+    """Extract phone number from SIP INVITE From header
+    Returns: phone number as string or None"""
+
+    from_header = invite_message.headers.get("From", "")
+
+    # Look for number pattern after "sip:"
+    match = re.search(r"sip:(\+?\d+)@", from_header)
+    if match:
+        return match.group(1)
+
+    # Alternate: look for number in display name
+    match = re.search(r'"(\+?\d+)".*<sip:', from_header)
+    if match:
+        return match.group(1)
+
+    return None

--- a/README.md
+++ b/README.md
@@ -15,42 +15,42 @@
     <th style="text-align: left; padding: 10px 0;">Description</th>
   </tr>
   <tr>
-    <td style="padding: 10px; background-color: #f6f8fa; font-weight: bold;">
+    <td style="padding: 10px; font-weight: bold;">
       Complete SIP Account Management
     </td>
-    <td style="padding: 10px; background-color: #f6f8fa; border-radius: 0 6px 6px 0;">
+    <td style="padding: 10px; border-radius: 0 6px 6px 0;">
       Easily create, register, and manage SIP accounts.
     </td>
   </tr>
   <tr>
-    <td style="padding: 10px; background-color: #f6f8fa; font-weight: bold;">
+    <td style="padding: 10px; font-weight: bold;">
       Custom Call Flows
     </td>
-    <td style="padding: 10px; background-color: #f6f8fa; border-radius: 0 6px 6px 0;">
+    <td style="padding: 10px; border-radius: 0 6px 6px 0;">
       Write scripts to automate call flows with your own business logic.
     </td>
   </tr> 
   <tr>
-    <td style="padding: 10px; background-color: #f6f8fa; font-weight: bold;">
+    <td style="padding: 10px; font-weight: bold;">
       UDP Transport Layer
     </td>
-    <td style="padding: 10px; background-color: #f6f8fa; border-radius: 0 6px 6px 0;">
+    <td style="padding: 10px; border-radius: 0 6px 6px 0;">
       Asynchronous, efficient UDP transport for sending and receiving SIP messages.
     </td>
   </tr>
   <tr>
-    <td style="padding: 10px; background-color: #f6f8fa; font-weight: bold;">
+    <td style="padding: 10px; font-weight: bold;">
       Flexible Call Handling
     </td>
-    <td style="padding: 10px; background-color: #f6f8fa; border-radius: 0 6px 6px 0;">
+    <td style="padding: 10px; border-radius: 0 6px 6px 0;">
       Handle incoming and outgoing SIP calls, play messages, and gather user input.
     </td>
   </tr>
   <tr>
-    <td style="padding: 10px; background-color: #f6f8fa; font-weight: bold;">
+    <td style="padding: 10px; font-weight: bold;">
       Fully Extensible
     </td>
-    <td style="padding: 10px; background-color: #f6f8fa; border-radius: 0 6px 6px 0;">
+    <td style="padding: 10px; border-radius: 0 6px 6px 0;">
       Includes an example bot for appointment booking, but you can easily write any SIP-based automation you need.
     </td>
   </tr>
@@ -73,16 +73,27 @@
 
 ## 🚀 **Installation**
 
-<div style="background-color: #f6f8fa; border-radius: 6px; padding: 16px;">
+### Option 1: Install from PyPI
 
-### Step 1: Clone the repository
+You can install PySIP directly from PyPI using pip:
+
+```bash
+pip install PySIPio
+```
+
+> [!CAUTION]
+> Note that the package name on PyPI is `PySIPio` and not `PySIP`
+
+### Option 2: Install from source
+
+#### Step 1: Clone the repository
 
 ```bash
 git clone https://github.com/moha-abdi/PySIP.git
 cd PySIP
 ```
 
-### Step 2: Install dependencies
+#### Step 2: Install dependencies
 
 Ensure you have Python 3.8+ installed. Install the required dependencies using:
 
@@ -90,25 +101,12 @@ Ensure you have Python 3.8+ installed. Install the required dependencies using:
 pip install -r requirements.txt
 ```
 
-### Step 3: Environment Setup
-
-Create a `.env` file to store your SIP account credentials and server details:
-
-```bash
-SIP_USERNAME=your_sip_username
-SIP_PASSWORD=your_sip_password
-SIP_SERVER=your_sip_server
-```
-
-</div>
-
 ---
 
 ## 📁 **Project Structure**
 
 The project is structured to provide a clean separation between the core SIP library and any custom scripts you want to write. Here's an overview of the project layout:
 
-<div style="background-color: #f6f8fa; border-radius: 6px; padding: 16px;">
 
 ```
 PySIP/
@@ -127,15 +125,21 @@ PySIP/
 └── README.md                   # Project documentation
 ```
 
-</div>
-
 ---
 
 ## 🏁 **Getting Started**
 
-<div style="background-color: #f6f8fa; border-radius: 6px; padding: 16px;">
+### Step 1: Environment Setup
 
-### Step 1: Setting Up a SIP Account
+Create a `.env` file in your working directory to store your SIP account credentials and server details:
+
+```bash
+SIP_USERNAME=your_sip_username
+SIP_PASSWORD=your_sip_password
+SIP_SERVER=your_sip_server
+```
+
+### Step 2: Setting Up a SIP Account
 
 A SIP account is essential for handling calls. To start, you need to create an instance of the `SipAccount` class, which requires your SIP credentials (username, password, and server). Here's how to do it:
 
@@ -154,7 +158,7 @@ account = SipAccount(
 )
 ```
 
-### Step 2: Registering the Account
+### Step 3: Registering the Account
 
 Once the `SipAccount` is created, the next step is to register it with the SIP server:
 
@@ -164,15 +168,11 @@ await account.register()
 
 This sends a SIP `REGISTER` request to the server to activate the account. Once registered, you can make calls or listen for incoming calls.
 
-</div>
-
 ---
 
 ## 📘 **Detailed Usage**
 
 ### SIP Account
-
-<div style="background-color: #f6f8fa; border-radius: 6px; padding: 16px;">
 
 The `SipAccount` class is at the core of PySIP. It handles all account-related tasks such as registration, making calls, and unregistering from the SIP server.
 
@@ -218,11 +218,7 @@ When you're done, unregister the account to gracefully close the session:
 await account.unregister()
 ```
 
-</div>
-
 ### Call Handling
-
-<div style="background-color: #f6f8fa; border-radius: 6px; padding: 16px;">
 
 The `CallHandler` is responsible for handling the call flow. It allows you to say messages, gather input from the caller, or transfer the call.
 
@@ -258,11 +254,8 @@ await call.reject()  # Reject the incoming call
 await call.busy()    # Mark the line as busy for the incoming call
 ```
 
-</div>
-
 ### UDP Transport
 
-<div style="background-color: #f6f8fa; border-radius: 6px; padding: 16px;">
 
 The `UdpHandler` is an internal module that manages the asynchronous sending and receiving of SIP messages over the network.
 
@@ -282,7 +275,6 @@ The `datagram_received()` method handles incoming messages, placing them in a qu
 self.data_q.put_nowait(data)
 ```
 
-</div>
 
 ---
 
@@ -290,7 +282,6 @@ self.data_q.put_nowait(data)
 
 To demonstrate PySIP in action, we've provided a basic example of an appointment booking bot. This bot allows callers to book appointments via a phone call.
 
-<div style="background-color: #f6f8fa; border-radius: 6px; padding: 16px;">
 
 ```python
 import asyncio
@@ -311,7 +302,7 @@ account = SipAccount(
 
 @account.on_incoming_call
 async def handle_incoming_call(call: SipCall):
-    await call.accept() 
+    await call.accept()
     await call.call_handler.say("We have received your call successfully")
 
 async def main():
@@ -333,7 +324,6 @@ if __name__ == "__main__":
     asyncio.run(main())
 ```
 
-</div>
 
 ---
 
@@ -355,6 +345,4 @@ Contributions are welcome! If you would like to contribute to the development of
 
 ---
 
-<div style="text-align: center; align: center; margin-top: 30px;" align="center">
-  <p align="center">Made with ❤️ by Moha Abdi</p>
-</div>
+<p align="center">Made with ❤️ by Moha Abdi</p>

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@
     <td style="padding: 10px; background-color: #f6f8fa; border-radius: 0 6px 6px 0;">
       Write scripts to automate call flows with your own business logic.
     </td>
-  </tr>
+  </tr> 
   <tr>
     <td style="padding: 10px; background-color: #f6f8fa; font-weight: bold;">
       UDP Transport Layer
@@ -56,8 +56,8 @@
   </tr>
 </table>
 
-
 ## 📚 **Table of Contents**
+
 1. [Installation](#-installation)
 2. [Project Structure](#-project-structure)
 3. [Getting Started](#-getting-started)
@@ -76,24 +76,30 @@
 <div style="background-color: #f6f8fa; border-radius: 6px; padding: 16px;">
 
 ### Step 1: Clone the repository
+
 ```bash
 git clone https://github.com/moha-abdi/PySIP.git
 cd PySIP
 ```
 
 ### Step 2: Install dependencies
+
 Ensure you have Python 3.8+ installed. Install the required dependencies using:
+
 ```bash
 pip install -r requirements.txt
 ```
 
 ### Step 3: Environment Setup
+
 Create a `.env` file to store your SIP account credentials and server details:
+
 ```bash
 SIP_USERNAME=your_sip_username
 SIP_PASSWORD=your_sip_password
 SIP_SERVER=your_sip_server
 ```
+
 </div>
 
 ---
@@ -120,6 +126,7 @@ PySIP/
 ├── .env.example                # Example environment configuration
 └── README.md                   # Project documentation
 ```
+
 </div>
 
 ---
@@ -129,6 +136,7 @@ PySIP/
 <div style="background-color: #f6f8fa; border-radius: 6px; padding: 16px;">
 
 ### Step 1: Setting Up a SIP Account
+
 A SIP account is essential for handling calls. To start, you need to create an instance of the `SipAccount` class, which requires your SIP credentials (username, password, and server). Here's how to do it:
 
 ```python
@@ -147,11 +155,15 @@ account = SipAccount(
 ```
 
 ### Step 2: Registering the Account
+
 Once the `SipAccount` is created, the next step is to register it with the SIP server:
+
 ```python
 await account.register()
 ```
+
 This sends a SIP `REGISTER` request to the server to activate the account. Once registered, you can make calls or listen for incoming calls.
+
 </div>
 
 ---
@@ -165,27 +177,47 @@ This sends a SIP `REGISTER` request to the server to activate the account. Once 
 The `SipAccount` class is at the core of PySIP. It handles all account-related tasks such as registration, making calls, and unregistering from the SIP server.
 
 #### **Instantiating a SIP Account**:
+
 ```python
 account = SipAccount(username, password, server)
 ```
 
 #### **Registering**:
+
 Call the `register()` method to register the SIP account with the server:
+
 ```python
 await account.register()
 ```
 
 #### **Making Calls**:
+
 The `make_call(destination)` method initiates a call to the destination number:
+
 ```python
 call = account.make_call("destination_number")
 ```
 
+#### **Handling Incoming Calls**:
+
+Use the `on_incoming_call` decorator to define a function that will handle incoming calls:
+
+```python
+@account.on_incoming_call
+async def handle_incoming_call(call: SipCall):
+    await call.accept()  # or call.reject() or call.busy()
+    await call.call_handler.say("Thank you for calling us!")
+    await call.call_handler.hangup()
+```
+
 #### **Unregistering**:
+
 When you're done, unregister the account to gracefully close the session:
+
 ```python
 await account.unregister()
 ```
+
 </div>
 
 ### Call Handling
@@ -195,21 +227,37 @@ await account.unregister()
 The `CallHandler` is responsible for handling the call flow. It allows you to say messages, gather input from the caller, or transfer the call.
 
 #### **Playing a message to the caller**:
+
 ```python
 await call_handler.say("Welcome to our service.")
 ```
 
 #### **Gathering user input**:
+
 Use `gather()` to gather input from the user, such as pressing a digit:
+
 ```python
 dtmf_key = await call_handler.gather(length=1, timeout=5)
 ```
 
 #### **Transferring the call**:
+
 You can forward the call to another number:
+
 ```python
 await call_handler.transfer_to("1234567890")
 ```
+
+#### **Accepting, Rejecting, or Setting Busy for Incoming Calls**:
+
+For incoming calls, you can use the following methods:
+
+```python
+await call.accept()  # Accept the incoming call
+await call.reject()  # Reject the incoming call
+await call.busy()    # Mark the line as busy for the incoming call
+```
+
 </div>
 
 ### UDP Transport
@@ -219,16 +267,21 @@ await call_handler.transfer_to("1234567890")
 The `UdpHandler` is an internal module that manages the asynchronous sending and receiving of SIP messages over the network.
 
 #### **Sending a message**:
+
 The `send_message()` method sends a UDP message to the SIP server or peer:
+
 ```python
 self.transport.sendto(message)
 ```
 
 #### **Receiving a datagram**:
+
 The `datagram_received()` method handles incoming messages, placing them in a queue for processing:
+
 ```python
 self.data_q.put_nowait(data)
 ```
+
 </div>
 
 ---
@@ -256,6 +309,11 @@ account = SipAccount(
     os.environ["SIP_SERVER"],
 )
 
+@account.on_incoming_call
+async def handle_incoming_call(call: SipCall):
+    await call.accept() 
+    await call.call_handler.say("We have received your call successfully")
+
 async def main():
     # Register the SIP account
     await account.register()
@@ -274,6 +332,7 @@ async def main():
 if __name__ == "__main__":
     asyncio.run(main())
 ```
+
 </div>
 
 ---
@@ -283,6 +342,7 @@ if __name__ == "__main__":
 While the appointment booking bot is just one example, **PySIP** is designed to let you create any SIP-based automation or custom script that fits your needs.
 
 To create your own script:
+
 1. **Create a Python file** in the `scripts/` directory.
 2. **Write your custom call logic** using the `CallHandler` class to control the call flow.
 3. **Use the `SipAccount` to register and make calls** as demonstrated in the example script.
@@ -296,5 +356,5 @@ Contributions are welcome! If you would like to contribute to the development of
 ---
 
 <div style="text-align: center; align: center; margin-top: 30px;" align="center">
-  <p align="center">Made with ❤️ by the Moha Abdi</p>
+  <p align="center">Made with ❤️ by Moha Abdi</p>
 </div>


### PR DESCRIPTION
Closes #41 

This PR adds support for handling incoming SIP calls using a decorator-based API, making it easier and more intuitive to handle incoming calls.

Key changes:
- Added `@on_incoming_call` decorator to SipAccount for registering incoming call handlers
- Implemented callback registration system in SipClient to manage incoming call events
- Added pending callbacks queue to handle decorators registered before client initialization
- Updated documentation with incoming call handling examples and usage
- Code cleanup and minor refactoring across multiple files
- Added PyPI installation option to README

Example usage:
```python
@account.on_incoming_call
async def handle_incoming_call(call: SipCall):
    await call.accept()
    await call.call_handler.say("Thank you for calling!")
```

This PR represents a significant feature addition that improves the developer experience for handling incoming calls, while also including some infrastructure improvements like PyPI publishing support and codec additions.